### PR TITLE
support non-default stream

### DIFF
--- a/src/torch_linear_assignment_cuda_kernel.cu
+++ b/src/torch_linear_assignment_cuda_kernel.cu
@@ -13,6 +13,7 @@
 #include <thrust/fill.h>
 
 #include <torch/extension.h>
+#include <ATen/cuda/CUDAContext.h>
 
 #include <limits>
 
@@ -222,7 +223,8 @@ void solve_cuda_batch(int bs, int nr, int nc,
 
   int blockSize = SMPCores();
   int gridSize = (bs + blockSize - 1) / blockSize;
-  solve_cuda_kernel_batch<<<gridSize, blockSize>>>(
+  at::cuda::CUDAStream stream = at::cuda::getCurrentCUDAStream();
+  solve_cuda_kernel_batch<<<gridSize, blockSize, 0, stream.stream()>>>(
     bs, nr, nc,
     cost,
     thrust::raw_pointer_cast(&u.front()),


### PR DESCRIPTION
The previous code did not specify a stream, so only the default stream could be used. 
I have modified the code with reference to Pytorch's built-in operators, and apply non-default stream for inferencing by the following method：
`

    with torch.cuda.stream(torch.cuda.Stream()):
        assignment = batch_linear_assignment(cost)
`