### PR TITLE
Query device only once

### DIFF
--- a/src/torch_linear_assignment_cuda_kernel.cu
+++ b/src/torch_linear_assignment_cuda_kernel.cu
@@ -224,7 +224,7 @@ void solve_cuda_batch(int device_index,
   thrust::fill(v.begin(), v.end(), (scalar_t) 0);
   thrust::fill(path.begin(), path.end(), -1);
 
-  int blockSize = SMPCores(device_index);
+  static const int blockSize = SMPCores(device_index);
   int gridSize = (bs + blockSize - 1) / blockSize;
   at::cuda::CUDAStream stream = at::cuda::getCurrentCUDAStream(device_index);
   solve_cuda_kernel_batch<<<gridSize, blockSize, 0, stream.stream()>>>(


### PR DESCRIPTION
Currently every invocation of `solve_cuda_batch` function checks the kind of GPU to determine the block size.

This is wasteful, and we observe the case where this takes a lot more than the computation itself.
The following is the profiling result using PyTorch profiler. The whole computation takes 7ms, and device query takes 3ms. This suggests that some sort of locking is happening.
(Note: I realized that my profiling does not include c5bf3e1db3005285af429fd88c9b593098b8adc3, so it should be faster on main branch.)

![Screenshot 2025-01-15 at 3 45 49 PM](https://github.com/user-attachments/assets/98122e3d-21e6-461e-abdb-f3eeeabe482a)

We can workaround this by caching the result.
The proposed change take advantage of static storage, so that it is initialized only once.

This works the same way as the current behavior, for cases where one process is assigned for each GPU.
(which I think is almost always the case, when using PyTorch.)

If there should be a case where one process is assigned to use multiple different kind of GPUs, then this might not give the indended value.
But such usecase would require fully customized PyTorch distributed trainign framework, so I assume it's highly unlikely.