### PR TITLE
Fix implicit fallthroughs in torch_linear_assignment_cuda_kernel.cu

### DIFF
--- a/src/torch_linear_assignment_cuda_kernel.cu
+++ b/src/torch_linear_assignment_cuda_kernel.cu
@@ -35,17 +35,20 @@ int SMPCores(int device_index)
   case 6: // Pascal
     if ((devProp.minor == 1) || (devProp.minor == 2)) return 128;
     else if (devProp.minor == 0) return 64;
+    break;
   case 7: // Volta and Turing
     if ((devProp.minor == 0) || (devProp.minor == 5)) return 64;
+    break;
   case 8: // Ampere
     if (devProp.minor == 0) return 64;
     else if (devProp.minor == 6) return 128;
     else if (devProp.minor == 9) return 128; // ada lovelace
+    break;
   case 9: // Hopper
     if (devProp.minor == 0) return 128;
-  // Unknown device;
+    break;
   }
-  return 128;
+  return 128; // Unknown device
 }
 
 


### PR DESCRIPTION
We use `-Wimplicit-fallthrough` throughout our codebase. In so doing, we've found that fallthroughs are associated with a very high bug rate.

This adds `break` to prevent implicit fallthroughs allowing the code to compile in our environment and improving performance by reducing unnecessary comparisons.