### PR TITLE
Adjust CUDA extension build conditions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,8 @@ def get_build_ext_modules():
     import torch
     import torch.utils.cpp_extension as torch_cpp_ext
 
-    if torch.backends.cuda.is_built() and int(os.environ.get("TLA_BUILD_CUDA", "1")) and torch.cuda.is_available():
+    if torch.backends.cuda.is_built() and int(os.environ.get("TLA_BUILD_CUDA", "1")):
+        print("building CUDA extension for torch-linear-assignment")
         compile_args = {"cxx": ["-O3"]}
         if os.environ.get("CC", None) is not None:
             compile_args["nvcc"] = ["-ccbin", os.environ["CC"]]
@@ -20,6 +21,8 @@ def get_build_ext_modules():
                 extra_compile_args=compile_args
             )
         ]
+    else:
+        print("Not building CUDA extension for torch-linear-assignment")
     return [
         torch_cpp_ext.CppExtension(
             "torch_linear_assignment._backend",


### PR DESCRIPTION
Removed check for CUDA availability before building the extension.

If we currently install this package in a dockerfile `torch.cuda.is_available()` will never be true (in docker build stage) and this will lead to lack of CUDA support in the installed package.

let me know if you need further clarification.