### PR TITLE
Modify CUDA build condition to include FORCE_CUDA

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ def get_build_ext_modules():
     import torch
     import torch.utils.cpp_extension as torch_cpp_ext
 
-    if torch.backends.cuda.is_built() and int(os.environ.get("TLA_BUILD_CUDA", "1")) and torch.cuda.is_available():
+    if torch.backends.cuda.is_built() and int(os.environ.get("TLA_BUILD_CUDA", "1")) and (os.environ.get("FORCE_CUDA") == "1" or torch.cuda.is_available()):
         compile_args = {"cxx": ["-O3"]}
         if os.environ.get("CC", None) is not None:
             compile_args["nvcc"] = ["-ccbin", os.environ["CC"]]


### PR DESCRIPTION
When building in GPU-less environments such as Docker build containers or CI runners, torch.cuda.is_available() returns False even when nvcc and all CUDA headers are present. This causes the build to silently fall back to a CPU-only extension, which then crashes at runtime when GPU tensors are passed to it.

FORCE_CUDA=1 is an established convention used by torchvision, torch-scatter, and other torch extension packages to signal that the CUDA extension should be compiled regardless of whether a GPU driver is available at build time. Adding support for it here makes torch-linear-assignment consistent with the broader PyTorch ecosystem and allows it to be installed in standard ML Docker build pipelines without requiring a GPU on the build host.

The existing TLA_BUILD_CUDA=0 escape hatch for disabling CUDA entirely is preserved and unchanged.