### PR TITLE
[ROCm] Add AMD GPU support via PyTorch hipify

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ You can choose CUDA version by
 export PATH=/usr/local/cuda-<version>/bin:"$PATH"
 ```
 
+The same source builds for AMD GPUs against a ROCm build of PyTorch: PyTorch's
+`CUDAExtension` runs hipify at build time to translate the CUDA sources, so the
+ordinary install commands above work unchanged on ROCm. To target a specific
+architecture, set `PYTORCH_ROCM_ARCH` (for example `export PYTORCH_ROCM_ARCH=gfx90a`)
+before installing.
+
 If you need custom C++ compiler, use the following command:
 ```bash
 CXX=<c++-compiler> CC=<gcc-compiler> pip install .

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import setuptools
 
 
@@ -10,6 +11,28 @@ def get_build_ext_modules():
         compile_args = {"cxx": ["-O3"]}
         if os.environ.get("CC", None) is not None:
             compile_args["nvcc"] = ["-ccbin", os.environ["CC"]]
+        extra_link_args = []
+        if sys.platform == "win32":
+            # c10.dll does not export the inherited c10::ValueError(SourceLocation,
+            # string) constructor (MSVC does not re-export inherited constructors
+            # even for C10_API classes).  Headers pulled in via <torch/extension.h>
+            # trigger TORCH_CHECK_VALUE which generates a __declspec(dllimport)
+            # reference to that constructor, causing LNK2001.  Redirect the missing
+            # dllimport thunk to Error(SourceLocation, string) which IS exported.
+            # ValueError IS-A Error with no extra data members.
+            # Fixed upstream by pytorch/pytorch#175340 (landed 2026-06-02), which
+            # exports the ValueError/NotImplementedError constructors on Windows;
+            # this workaround can be dropped once that fix is in the minimum
+            # supported PyTorch.
+            _val_imp = (
+                "__imp_??0ValueError@c10@@QEAA@USourceLocation@1@"
+                "V?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@Z"
+            )
+            _err_imp = (
+                "__imp_??0Error@c10@@QEAA@USourceLocation@1@"
+                "V?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@Z"
+            )
+            extra_link_args.append(f"/ALTERNATENAME:{_val_imp}={_err_imp}")
         return [
             torch_cpp_ext.CUDAExtension(
                 "torch_linear_assignment._backend",
@@ -17,7 +40,8 @@ def get_build_ext_modules():
                     "src/torch_linear_assignment_cuda.cpp",
                     "src/torch_linear_assignment_cuda_kernel.cu"
                 ],
-                extra_compile_args=compile_args
+                extra_compile_args=compile_args,
+                extra_link_args=extra_link_args,
             )
         ]
     return [


### PR DESCRIPTION
This adds AMD GPU (ROCm) support. The CUDA backend is a PyTorch CUDAExtension, so building it against a ROCm build of PyTorch runs hipify at build time to translate the CUDA sources to HIP automatically. No changes to the CUDA kernel or host C++ sources are required, and the CUDA build path is unchanged.

Two changes support the ROCm build:

- `setup.py`: on Windows, `c10.dll` does not export the inherited `c10::ValueError(SourceLocation, string)` constructor (MSVC does not re-export inherited constructors even for `C10_API` classes). Headers pulled in via `<torch/extension.h>` trigger `TORCH_CHECK_VALUE`, which generates a dllimport reference to that constructor and fails to link with LNK2001. A win32-only `/ALTERNATENAME` linker directive redirects the missing thunk to `c10::Error(SourceLocation, string)`, which is exported; `ValueError` IS-A `Error` with no additional data members, so the redirect is semantically safe. The directive is guarded by `sys.platform == "win32"` and does not affect Linux or the CUDA build. This is fixed upstream by pytorch/pytorch#175340, so the directive can be removed once that fix is in the minimum supported PyTorch.
- `README`: a note in the install section explaining that the ordinary `pip install` works on ROCm and that `PYTORCH_ROCM_ARCH` selects the target architecture.

## Test Plan

Build against a ROCm PyTorch and run the suite on an AMD GPU:

```
PYTORCH_ROCM_ARCH=gfx1100 pip install -e .
pytest tests/
```

On Linux gfx1100 (Radeon Pro W7800, ROCm 7.2.1) and Windows gfx1201 (RX 9070 XT) the full suite passes 3/3 (`test_simple`, `test_cuda_equal_to_cpu`, `test_compare_to_scipy`). On Linux gfx90a (MI250X) the assignment checks pass with valid, optimal, deterministic GPU assignments. The CUDA build path is unchanged.

Authored with assistance from Claude.
